### PR TITLE
Add Catalan i18n catalog and shared utilities

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,21 +1,263 @@
-export const i18n = {
-  locale: 'ca',
-  strings: {
-    welcome: 'Benvingut/da a la llibreta docent',
-    connect_backup: "Connecta fitxer d'autocòpia",
-    search_placeholder: 'Cerca...',
-    autosave_local: 'Local',
+const strings = {
+  general: {
+    desa: 'Desa',
+    "cancel·la": 'Cancel·la',
+    tanca: 'Tanca',
+    accepta: 'Accepta',
+    elimina: 'Elimina',
+    editar: 'Edita',
+    duplicar: 'Duplica',
+    confirma: 'Confirma',
+    copia: 'Copia',
+    connectaAutocopia: "Connecta l'autocòpia",
+    desconnecta: 'Desconnecta',
+    canviaContrasenya: 'Canvia la contrasenya',
+    backupAra: 'Fes una còpia ara',
+    llistaBackups: 'Mostra les còpies de seguretat',
+    fsConnectat: 'Sistema de fitxers connectat',
+    fsDesconnectat: 'Sistema de fitxers desconnectat',
+    autosaveOk: 'Autodesat correcte',
+    autosaveWarn: 'Autodesat amb avisos',
+    autosaveErr: "Error d'autodesat",
+    lockActiu: 'Edició bloquejada',
+    conflicteDetectat: "S'ha detectat un conflicte",
+    conflicteResol: 'Resol el conflicte',
+    contrasenyaIncorrecta: 'Contrasenya incorrecta',
+    contrasenyaCanviada: 'Contrasenya actualitzada',
+  },
+  rubrica: {
+    na: 'No assolit',
+    as: 'Assoliment satisfactori',
+    an: 'Assoliment notable',
+    ae: "Assoliment excel·lent",
+    mitjanaCA: "Mitjana del criteri d'avaluació",
+    notaCE: 'Nota del criteri específic',
+    veureUnaActivitat: 'Veure una activitat',
+    veureMultiplesActivitats: 'Veure múltiples activitats',
+  },
+  numeric: {
+    categories: 'Categories',
+    pesGlobalCategoria: 'Pes global de la categoria',
+    pesActivitat: "Pes de l'activitat",
+    notaFinal: 'Nota final',
+  },
+  fitxaAlumne: {
+    resum: 'Resum',
+    avaluacions: 'Avaluacions',
+    assistencia: 'Assistència',
+    incidencies: 'Incidències',
+    nese: 'Necessitats específiques',
+    exportacions: 'Exportacions',
+  },
+  exportacions: {
+    exportaCSV: 'Exporta CSV',
+    exportaDOCX: 'Exporta DOCX',
+    backupXifrat: 'Còpia de seguretat xifrada',
+  },
+  calendari: {
+    trimestres: 'Trimestres',
+    diesLectius: 'Dies lectius',
+    festius: 'Festius',
+    excepcions: 'Excepcions',
+    versionsHorari: "Versions d'horari",
+    activaDesDe: 'Activa des de',
+    simula: 'Simula',
+  },
+  errors: {
+    valorInvalid: 'Valor invàlid',
+    intervalInvalid: 'Interval invàlid',
+    decimalsNoPermesos: 'Nombre de decimals no permès',
+    carregant: 'Carregant…',
+    llest: 'Llest',
   },
 };
 
-export function t(key) {
-  return i18n.strings[key] ?? key;
+const vowelMonths = new Set(['a', 'à', 'á', 'e', 'é', 'è', 'i', 'í', 'ï', 'o', 'ó', 'ò', 'u', 'ú', 'ü']);
+
+const defaultQualitativeRanges = Object.freeze({
+  NA: Object.freeze([0.0, 4.9]),
+  AS: Object.freeze([5.0, 6.9]),
+  AN: Object.freeze([7.0, 8.9]),
+  AE: Object.freeze([9.0, 10.0]),
+});
+
+const defaultRounding = Object.freeze({ decimals: 1, mode: 'half-up' });
+
+function ensureFiniteNumber(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw fail('valorInvalid', { value });
+  }
+  return value;
 }
 
-export function formatDate() {
-  console.warn('formatDate pendent d\'implementació');
+function normalizeDecimals(decimals) {
+  const dec = Number(decimals ?? 0);
+  if (!Number.isInteger(dec) || dec < 0 || dec > 3) {
+    throw fail('decimalsNoPermesos', { decimals });
+  }
+  return dec;
 }
 
-export function formatNumber() {
-  console.warn('formatNumber pendent d\'implementació');
+function toDate(value) {
+  if (value instanceof Date) {
+    const time = value.getTime();
+    if (Number.isNaN(time)) {
+      throw fail('valorInvalid', { value });
+    }
+    return new Date(time);
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw fail('valorInvalid', { value });
+  }
+  return date;
 }
+
+function pad(value) {
+  return String(value).padStart(2, '0');
+}
+
+export function fail(msgKey, extra) {
+  const message = strings.errors[msgKey] || msgKey;
+  const error = new Error(message);
+  error.code = msgKey;
+  if (extra !== undefined) {
+    error.extra = extra;
+  }
+  throw error;
+}
+
+export function formatNumberComma(value, decimals = 1) {
+  ensureFiniteNumber(value);
+  const dec = normalizeDecimals(decimals);
+  const sign = value < 0 ? '-' : '';
+  const absolute = Math.abs(value);
+  const fixed = absolute.toFixed(dec);
+  const [integerPartRaw, fractionPart] = fixed.split('.');
+  const integerPart = integerPartRaw.replace(/\B(?=(\d{3})+(?!\d))/gu, '\u202f');
+  if (dec === 0) {
+    return `${sign}${integerPart}`;
+  }
+  return `${sign}${integerPart},${fractionPart}`;
+}
+
+export function parseNumberComma(input) {
+  if (input === null || input === undefined || input === '') {
+    throw fail('valorInvalid', { value: input });
+  }
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    return input;
+  }
+  const raw = String(input).trim();
+  if (!raw) {
+    throw fail('valorInvalid', { value: input });
+  }
+  const cleaned = raw.replace(/[\u202f\u00a0\s]/gu, '');
+  const sign = cleaned[0] === '-' || cleaned[0] === '+' ? cleaned[0] : '';
+  const unsigned = sign ? cleaned.slice(1) : cleaned;
+  if (!/^(?:\d+(?:[.,]\d+)*|[.,]\d+)$/u.test(unsigned)) {
+    throw fail('valorInvalid', { value: input });
+  }
+  const commaCount = (unsigned.match(/,/gu) || []).length;
+  const dotCount = (unsigned.match(/\./gu) || []).length;
+  const lastComma = cleaned.lastIndexOf(',');
+  const lastDot = cleaned.lastIndexOf('.');
+  let decimalSeparator = null;
+  if (commaCount > 0 && dotCount > 0) {
+    decimalSeparator = lastComma > lastDot ? ',' : '.';
+  } else if (commaCount === 1) {
+    decimalSeparator = ',';
+  } else if (dotCount === 1) {
+    decimalSeparator = '.';
+  }
+
+  let normalized;
+  if (decimalSeparator) {
+    const index = cleaned.lastIndexOf(decimalSeparator);
+    const integerDigits = cleaned
+      .slice(sign ? 1 : 0, index)
+      .replace(/[.,]/gu, '') || '0';
+    const fractionDigits = cleaned.slice(index + 1).replace(/[.,]/gu, '');
+    normalized = `${sign}${integerDigits}.${fractionDigits}`;
+  } else {
+    const integerDigits = unsigned.replace(/[.,]/gu, '') || '0';
+    normalized = `${sign}${integerDigits}`;
+  }
+
+  if (!/^[-+]?\d*(?:\.\d*)?$/u.test(normalized) || normalized === '' || normalized === '+' || normalized === '-') {
+    throw fail('valorInvalid', { value: input });
+  }
+  const number = Number(normalized);
+  if (!Number.isFinite(number)) {
+    throw fail('valorInvalid', { value: input });
+  }
+  return number;
+}
+
+export function formatDateCAT(value) {
+  const date = toDate(value);
+  const day = new Intl.DateTimeFormat('ca-ES', { day: 'numeric' }).format(date);
+  let month = new Intl.DateTimeFormat('ca-ES', { month: 'short' }).format(date).toLocaleLowerCase('ca-ES');
+  const year = new Intl.DateTimeFormat('ca-ES', { year: 'numeric' }).format(date);
+  const needsApostrophe = month && vowelMonths.has(month[0]);
+  const preposition = needsApostrophe ? 'd’' : 'de ';
+  return `${day} ${preposition}${month} de ${year}`;
+}
+
+export function formatDateISO(value) {
+  const date = toDate(value);
+  const year = date.getUTCFullYear();
+  const month = pad(date.getUTCMonth() + 1);
+  const day = pad(date.getUTCDate());
+  return `${year}-${month}-${day}`;
+}
+
+export function formatDateTimeCAT(value) {
+  const date = toDate(value);
+  const datePart = formatDateCAT(date);
+  const timePart = new Intl.DateTimeFormat('ca-ES', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(date);
+  return `${datePart}, ${timePart}`;
+}
+
+const qualiLabels = {
+  NA: `${strings.rubrica.na} (NA)`,
+  AS: `${strings.rubrica.as} (AS)`,
+  AN: `${strings.rubrica.an} (AN)`,
+  AE: `${strings.rubrica.ae} (AE)`,
+};
+
+export function qualiLabel(code) {
+  const key = String(code || '').toUpperCase();
+  return qualiLabels[key] || code;
+}
+
+export function qualiShort(code) {
+  const key = String(code || '').toUpperCase();
+  if (qualiLabels[key]) {
+    return key;
+  }
+  return code;
+}
+
+export const i18n = {
+  locale: 'ca',
+  strings,
+  formatNumberComma,
+  parseNumberComma,
+  formatDateCAT,
+  formatDateISO,
+  formatDateTimeCAT,
+  qualiLabel,
+  qualiShort,
+  defaultQualitativeRanges,
+  defaultRounding,
+  fail,
+};
+
+export default i18n;
+
+export { strings, defaultQualitativeRanges, defaultRounding };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,20 +1,345 @@
-export function debounce(fn, ms = 200) {
-  let timeoutId;
-  return (...args) => {
-    window.clearTimeout(timeoutId);
-    timeoutId = window.setTimeout(() => {
+import { i18n, fail, formatNumberComma, parseNumberComma } from './i18n.js';
+
+export function assert(condition, msg = 'S\'ha produït un error inesperat') {
+  if (!condition) {
+    throw new Error(msg);
+  }
+}
+
+export function debounce(fn, ms = 300) {
+  assert(typeof fn === 'function', 'Cal una funció a debounce');
+  let timeoutId = null;
+  const wrapper = (...args) => {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+    timeoutId = setTimeout(() => {
+      timeoutId = null;
       fn(...args);
     }, ms);
   };
+  wrapper.cancel = () => {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+  return wrapper;
 }
 
-export const formatters = {
-  currency() {
-    console.warn('Formatador de moneda pendent');
-    return null;
-  },
-  percent() {
-    console.warn('Formatador de percentatge pendent');
-    return null;
-  },
-};
+function serializeCell(value, { sep, decimalComma }) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (decimalComma) {
+      const [integerPart, fractionalPart] = String(value).split('.');
+      return fractionalPart ? `${integerPart},${fractionalPart}` : integerPart;
+    }
+    return String(value);
+  }
+  if (value instanceof Date) {
+    return i18n.formatDateISO(value);
+  }
+  const text = String(value);
+  const escaped = text.replace(/"/gu, '""');
+  if (escaped.includes(sep) || /[\r\n]/u.test(escaped) || escaped !== text) {
+    return `"${escaped}"`;
+  }
+  return escaped;
+}
+
+export function toCSV(rows, { sep = ';', decimalComma = true, headers = null } = {}) {
+  assert(Array.isArray(rows), 'Cal una llista de files per exportar a CSV');
+  const lines = [];
+  let resolvedHeaders = headers;
+
+  if (!resolvedHeaders && rows.length > 0) {
+    const firstRow = rows[0];
+    if (firstRow && typeof firstRow === 'object' && !Array.isArray(firstRow)) {
+      resolvedHeaders = Object.keys(firstRow);
+    }
+  }
+
+  if (resolvedHeaders) {
+    lines.push(
+      resolvedHeaders
+        .map((header) => serializeCell(header, { sep, decimalComma: false }))
+        .join(sep),
+    );
+  }
+
+  for (const row of rows) {
+    let cells;
+    if (Array.isArray(row)) {
+      cells = row;
+    } else if (row && typeof row === 'object') {
+      const keys = resolvedHeaders || Object.keys(row);
+      cells = keys.map((key) => row[key]);
+    } else {
+      cells = [row];
+    }
+    const serialized = cells.map((cell) => {
+      if (typeof cell === 'number' && Number.isFinite(cell) && decimalComma) {
+        const [integerPart, fractionalPart = ''] = String(cell).split('.');
+        const formatted = fractionalPart ? `${integerPart},${fractionalPart}` : integerPart;
+        return serializeCell(formatted, { sep, decimalComma });
+      }
+      return serializeCell(cell, { sep, decimalComma });
+    });
+    lines.push(serialized.join(sep));
+  }
+
+  return lines.join('\r\n');
+}
+
+export function numberToComma(value, decimals = 1) {
+  return formatNumberComma(value, decimals);
+}
+
+export function commaToNumber(value) {
+  return parseNumberComma(value);
+}
+
+export function safeRound(value, decimals = 1, mode = 'half-up') {
+  assert(typeof value === 'number' && Number.isFinite(value), 'Cal un nombre finit per arrodonir');
+  const dec = Number(decimals);
+  if (!Number.isInteger(dec) || dec < 0 || dec > 3) {
+    fail('decimalsNoPermesos', { decimals });
+  }
+  if (mode !== 'half-up') {
+    fail('valorInvalid', { mode });
+  }
+  const factor = 10 ** dec;
+  const scaled = Math.sign(value) * Math.round(Math.abs(value) * factor + Number.EPSILON);
+  const result = scaled / factor;
+  return Number(result.toFixed(dec));
+}
+
+export function isISODate(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(value)) {
+    return false;
+  }
+  const [year, month, day] = value.split('-').map((part) => Number(part));
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day;
+}
+
+function toDate(value) {
+  if (value instanceof Date) {
+    const time = value.getTime();
+    if (Number.isNaN(time)) {
+      throw fail('valorInvalid', { value });
+    }
+    return new Date(time);
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw fail('valorInvalid', { value });
+  }
+  return date;
+}
+
+export function toISODate(value) {
+  const date = toDate(value);
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function fromISODate(value) {
+  assert(typeof value === 'string', 'Cal una cadena ISO per convertir a data');
+  if (!isISODate(value)) {
+    throw fail('valorInvalid', { value });
+  }
+  const [year, month, day] = value.split('-').map((part) => Number(part));
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+const focusableSelectors = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+];
+
+function getFocusableElements(container) {
+  if (!container || typeof container.querySelectorAll !== 'function') {
+    return [];
+  }
+  const nodes = container.querySelectorAll(focusableSelectors.join(','));
+  return Array.from(nodes).filter((el) => typeof el.focus === 'function');
+}
+
+export function focusTrap(container, { initialFocus = null, escapeDeactivates = true, returnFocus = true } = {}) {
+  let previousActive = null;
+  let active = false;
+  let focusables = [];
+
+  const handleKeyDown = (event) => {
+    if (!active || event.key !== 'Tab') {
+      if (escapeDeactivates && event.key === 'Escape') {
+        event.stopPropagation();
+        deactivate();
+      }
+      return;
+    }
+
+    focusables = getFocusableElements(container);
+    if (focusables.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const current = event.target;
+    const contains = container && typeof container.contains === 'function';
+    const isElement = typeof Element !== 'undefined' && current instanceof Element;
+    const isInside = contains && isElement ? container.contains(current) : true;
+    if (event.shiftKey) {
+      if (current === first || !isInside) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (current === last || !isInside) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const activate = () => {
+    if (active) return;
+    if (typeof document === 'undefined') {
+      active = true;
+      return;
+    }
+    active = true;
+    previousActive = document.activeElement;
+    focusables = getFocusableElements(container);
+    const focusTarget =
+      (typeof initialFocus === 'function' ? initialFocus() : initialFocus) || focusables[0];
+    if (focusTarget && typeof focusTarget.focus === 'function') {
+      focusTarget.focus();
+    }
+    if (container && typeof container.addEventListener === 'function') {
+      container.addEventListener('keydown', handleKeyDown, true);
+    }
+  };
+
+  const deactivate = () => {
+    if (!active) return;
+    active = false;
+    if (container && typeof container.removeEventListener === 'function') {
+      container.removeEventListener('keydown', handleKeyDown, true);
+    }
+    if (returnFocus && previousActive && typeof previousActive.focus === 'function') {
+      previousActive.focus();
+    }
+  };
+
+  return { activate, deactivate };
+}
+
+export function restoreFocus(element) {
+  if (element && typeof element.focus === 'function') {
+    element.focus();
+  }
+  return element;
+}
+
+export function prefersReducedMotion() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function uid(prefix = 'id') {
+  const time = Date.now().toString(36);
+  const random = Math.floor(Math.random() * 1e6).toString(36);
+  return `${prefix}-${time}-${random}`;
+}
+
+export function clamp(value, min, max) {
+  assert(typeof value === 'number' && typeof min === 'number' && typeof max === 'number', 'clamp requereix números');
+  return Math.min(Math.max(value, min), max);
+}
+
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveTime(value) {
+  if (value instanceof Date) {
+    const time = value.getTime();
+    if (Number.isNaN(time)) {
+      throw fail('valorInvalid', { value });
+    }
+    return time;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  throw fail('valorInvalid', { value });
+}
+
+export function relativeTime(from, to = Date.now()) {
+  const fromMs = resolveTime(from);
+  const toMs = resolveTime(to);
+  const diffMs = toMs - fromMs;
+  const past = diffMs >= 0;
+  const delta = Math.abs(diffMs) / 1000;
+  if (delta < 45) {
+    return 'ara mateix';
+  }
+  const minutes = delta / 60;
+  if (minutes < 1.5) {
+    return past ? 'fa 1 min' : 'd\'aquí 1 min';
+  }
+  if (minutes < 45) {
+    const value = Math.round(minutes);
+    return past ? `fa ${value} min` : `d'aquí ${value} min`;
+  }
+  const hours = minutes / 60;
+  if (hours < 1.5) {
+    return past ? 'fa 1 h' : "d'aquí 1 h";
+  }
+  if (hours < 22) {
+    const value = Math.round(hours);
+    return past ? `fa ${value} h` : `d'aquí ${value} h`;
+  }
+  const days = hours / 24;
+  if (days < 1.5) {
+    return past ? 'fa 1 dia' : "d'aquí 1 dia";
+  }
+  if (days < 26) {
+    const value = Math.round(days);
+    return past ? `fa ${value} dies` : `d'aquí ${value} dies`;
+  }
+  const months = days / 30;
+  if (months < 1.5) {
+    return past ? 'fa 1 mes' : "d'aquí 1 mes";
+  }
+  if (months < 18) {
+    const value = Math.round(months);
+    return past ? `fa ${value} mesos` : `d'aquí ${value} mesos`;
+  }
+  const years = days / 365;
+  if (years < 1.5) {
+    return past ? 'fa 1 any' : "d'aquí 1 any";
+  }
+  const value = Math.round(years);
+  return past ? `fa ${value} anys` : `d'aquí ${value} anys`;
+}


### PR DESCRIPTION
## Summary
- flesh out the i18n module with Catalan strings, number/date formatters, qualitative labels and default configuration
- add error helper wiring so callers receive localized messages when validation fails
- implement pure utility helpers for CSV exports, numeric/date conversions, focus trapping, focus restoration, and relative time formatting

## Testing
- `node --input-type=module <<'EOF'
import { i18n } from './src/i18n.js';
import { toCSV, commaToNumber, numberToComma } from './src/utils.js';
const nums = ['7,25', '7.25', '1 234,5', '1\u202f234,5', '1.234,5'];
for (const str of nums) {
  const n = commaToNumber(str);
  const back = numberToComma(n);
  console.log(str, '->', n, '->', back);
}
console.log('formatDateCAT', i18n.formatDateCAT('2025-10-03'));
console.log('formatDateCAT abril', i18n.formatDateCAT('2025-04-01'));
console.log('formatDateCAT juny', i18n.formatDateCAT('2025-06-15'));
const csv = toCSV([
  { nom: 'Joana', nota: 3.5 },
  ['Linia amb', 'punt i coma;'],
  ['Text "entre" cometes'],
]);
console.log(csv);
EOF`
- `node --input-type=module <<'EOF'
import { relativeTime } from './src/utils.js';
const now = Date.now();
console.log(relativeTime(now - 2 * 60 * 60 * 1000));
console.log(relativeTime(now - 30 * 1000));
console.log(relativeTime(now + 5 * 60 * 1000));
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68e26c31794c83248565ba07cc4b99df