### PR TITLE
Ensure app initialises after DOM ready

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -454,9 +454,15 @@ async function init() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function boot() {
   init().catch((error) => {
     console.error('Failed to initialise application', error);
     emitUIEvent('app:error', { error });
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', boot, { once: true });
+} else {
+  boot();
+}


### PR DESCRIPTION
## Summary
- ensure the application boot logic runs even if the DOMContentLoaded event has already fired by falling back to immediate initialisation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2b5757e2c8324944dd47c73837b5d